### PR TITLE
Change loan sale mechanism to specify unit price during sale

### DIFF
--- a/contracts/beneficiary.sol
+++ b/contracts/beneficiary.sol
@@ -268,7 +268,6 @@ contract SPexBeneficiary {
         require(buyAmount <= sellItem.amountRemaining, "buyAmount larger than amount on sale");
         uint requiredPayment = sellItem.pricePerFil * buyAmount / 1 ether;
         require(msg.value == requiredPayment, "Paid amount not equal to sale price");
-        payable(seller).transfer(requiredPayment);
         _updateLenderOwedAmount(seller, minerId);
         _updateLenderOwedAmount(msg.sender, minerId);
 
@@ -280,6 +279,8 @@ contract SPexBeneficiary {
         buyerLoan.lastAmount += buyAmount;
         buyerLoan.principleAmount += principleChange;
         sellItem.amountRemaining -= buyAmount;
+        
+        payable(seller).transfer(requiredPayment);
 
         emit EventBuyLoan(msg.sender, seller, minerId, buyAmount, sellItem.pricePerFil);
     }


### PR DESCRIPTION
In this version of the loan sale mechanism, the seller specifies the intended unit price during the sale. The unit price reflects the price the buyer must pay for each FIL of the loan that he/she buys.

The buyer can buy an arbitrary amount of the loan, as long as the purchase amount is smaller than the amount listed for sale.

In consideration that the motive to sell a loan is to liquidate the loan, any repayment that occurs when the loan is on sale will reduce the lender's sale amount by the repayment amount.