### PR TITLE
Fix arithmetic overflow error at repayment

### DIFF
--- a/contracts/beneficiary.sol
+++ b/contracts/beneficiary.sol
@@ -23,7 +23,6 @@ contract SPexBeneficiary {
 
     event EventPledgeBeneficiaryToSpex(CommonTypes.FilActorId, address, uint, uint, address);
     event EventReleaseBeneficiary(CommonTypes.FilActorId, CommonTypes.FilAddress);
-    event EventReleaseBeneficiaryAgain(CommonTypes.FilActorId, CommonTypes.FilAddress);
     event EventLendToMiner(address, CommonTypes.FilActorId, uint);
     event EventChangeMinerDelegator(CommonTypes.FilActorId, address);
     event EventChangeMinerMaxDebtAmount(CommonTypes.FilActorId, uint);

--- a/contracts/beneficiary.sol
+++ b/contracts/beneficiary.sol
@@ -254,15 +254,15 @@ contract SPexBeneficiary {
         require(miner.disabled == false, "Lending for this miner is disabled");
         require(miner.lenders.length <= miner.maxLenderCount, "Lenders list too long");
         require(msg.value >= miner.minLendAmount, "Lend amount smaller than minimum allowed");
+        if (_loans[msg.sender][minerId].lastUpdateTime == 0){
+            miner.lenders.push(msg.sender);
+        }
         uint minerTotalDebtAmount = _updateMinerDebtAmounts(minerId);
         require((minerTotalDebtAmount + msg.value) <= miner.maxDebtAmount, "Debt amount after lend large than allowed by miner");
 
         uint64 minerIdUint64 = CommonTypes.FilActorId.unwrap(minerId);
         uint minerBalance = FilAddress.toAddress(minerIdUint64).balance;
         require((minerTotalDebtAmount + msg.value) <= (minerBalance * _maxDebtRate / RATE_BASE), "Debt rate of miner after lend larger than allowed");
-        if (_loans[msg.sender][minerId].lastUpdateTime == 0){
-            miner.lenders.push(msg.sender);
-        }
         _increaseOwedAmounts(msg.sender, minerId, msg.value);
         payable(miner.receiveAddress).transfer(msg.value);
         emit EventLendToMiner(msg.sender, minerId, msg.value);

--- a/contracts/beneficiary.sol
+++ b/contracts/beneficiary.sol
@@ -388,14 +388,13 @@ contract SPexBeneficiary {
             loan.lastAmount = 0;
             
             //Delete lender from miner's lender list
-            uint i;
-            for (i = 0; i < miner.lenders.length; i++) {
-                if (miner.lenders[i] == msg.sender) {
+            for (uint i = 0; i < miner.lenders.length; i++) {
+                if (miner.lenders[i] == lender) {
+                    miner.lenders[i] = miner.lenders[miner.lenders.length - 1];
+                    miner.lenders.pop();
                     break;
                 }
             }
-            miner.lenders[i] = miner.lenders[miner.lenders.length - 1];
-            miner.lenders.pop();
         }
 
         //The user have payed back more than interest in this case, so all remaining debt are principle

--- a/contracts/beneficiary.sol
+++ b/contracts/beneficiary.sol
@@ -43,7 +43,6 @@ contract SPexBeneficiary {
         address receiveAddress;
         bool disabled;
         uint principleAmount;
-        uint lastUpdateTime;
         address[] lenders;
     }
 
@@ -149,7 +148,6 @@ contract SPexBeneficiary {
             receiveAddress: receiveAddress,
             disabled: disabled,
             principleAmount: 0,
-            lastUpdateTime: block.timestamp,
             lenders: new address[](0)
         });
         _miners[minerId] = miner;

--- a/contracts/beneficiary.sol
+++ b/contracts/beneficiary.sol
@@ -230,7 +230,9 @@ contract SPexBeneficiary {
         uint64 minerIdUint64 = CommonTypes.FilActorId.unwrap(minerId);
         uint minerBalance = FilAddress.toAddress(minerIdUint64).balance;
         require((minerTotalDebtAmount + msg.value) <= (minerBalance * _maxDebtRate / RATE_BASE), "Debt rate of miner after lend larger than allowed");
-        miner.lenders.push(msg.sender);
+        if (_loans[msg.sender][minerId].lastUpdateTime == 0){
+            miner.lenders.push(msg.sender);
+        }
         _increaseOwedAmounts(msg.sender, minerId, msg.value);
         payable(miner.receiveAddress).transfer(msg.value);
         emit EventLendToMiner(msg.sender, minerId, msg.value);
@@ -389,6 +391,7 @@ contract SPexBeneficiary {
                 if (miner.lenders[i] == lender) {
                     miner.lenders[i] = miner.lenders[miner.lenders.length - 1];
                     miner.lenders.pop();
+                    delete _loans[lender][minerId];
                     break;
                 }
             }


### PR DESCRIPTION
The previous version of the contract throws an "arithmetic overflow" error at complete repayment of the last loan after lending from more than one lender. The root cause of this problem is that the sum of the calculated owed amounts of all loans differs from the calculated miner debt, which is most likely caused by calculation error.

Sacrificing some elegance, this solution fixes the above problem by calculating the miner total debt by adding up the owed amounts from all loans lend to the miner.