### PR TITLE
Calcluate fee as percentage of interest

### DIFF
--- a/contracts/beneficiary.sol
+++ b/contracts/beneficiary.sol
@@ -23,7 +23,6 @@ contract SPexBeneficiary {
 
     event EventPledgeBeneficiaryToSpex(CommonTypes.FilActorId, address, uint, uint, address);
     event EventReleaseBeneficiary(CommonTypes.FilActorId, CommonTypes.FilAddress);
-    event EventReleaseBeneficiaryAgain(CommonTypes.FilActorId, CommonTypes.FilAddress);
     event EventLendToMiner(address, CommonTypes.FilActorId, uint);
     event EventChangeMinerDelegator(CommonTypes.FilActorId, address);
     event EventChangeMinerMaxDebtAmount(CommonTypes.FilActorId, uint);

--- a/contracts/beneficiary.sol
+++ b/contracts/beneficiary.sol
@@ -254,15 +254,15 @@ contract SPexBeneficiary {
         require(miner.disabled == false, "Lending for this miner is disabled");
         require(miner.lenders.length <= miner.maxLenderCount, "Lenders list too long");
         require(msg.value >= miner.minLendAmount, "Lend amount smaller than minimum allowed");
+        if (_loans[msg.sender][minerId].lastUpdateTime == 0){
+            miner.lenders.push(msg.sender);
+        }
         uint minerTotalDebtAmount = _updateMinerDebtAmounts(minerId);
         require((minerTotalDebtAmount + msg.value) <= miner.maxDebtAmount, "Debt amount after lend large than allowed by miner");
 
         uint64 minerIdUint64 = CommonTypes.FilActorId.unwrap(minerId);
         uint minerBalance = FilAddress.toAddress(minerIdUint64).balance;
         require((minerTotalDebtAmount + msg.value) <= (minerBalance * _maxDebtRate / RATE_BASE), "Debt rate of miner after lend larger than allowed");
-        if (_loans[msg.sender][minerId].lastUpdateTime == 0){
-            miner.lenders.push(msg.sender);
-        }
         _increaseOwedAmounts(msg.sender, minerId, msg.value);
         payable(miner.receiveAddress).transfer(msg.value);
         emit EventLendToMiner(msg.sender, minerId, msg.value);

--- a/contracts/beneficiary.sol
+++ b/contracts/beneficiary.sol
@@ -388,14 +388,13 @@ contract SPexBeneficiary {
             loan.lastAmount = 0;
             
             //Delete lender from miner's lender list
-            uint i;
-            for (i = 0; i < miner.lenders.length; i++) {
-                if (miner.lenders[i] == msg.sender) {
+            for (uint i = 0; i < miner.lenders.length; i++) {
+                if (miner.lenders[i] == lender) {
+                    miner.lenders[i] = miner.lenders[miner.lenders.length - 1];
+                    miner.lenders.pop();
                     break;
                 }
             }
-            miner.lenders[i] = miner.lenders[miner.lenders.length - 1];
-            miner.lenders.pop();
         }
 
         //The user have payed back more than interest in this case, so all remaining debt are principle

--- a/contracts/beneficiary.sol
+++ b/contracts/beneficiary.sol
@@ -43,7 +43,6 @@ contract SPexBeneficiary {
         address receiveAddress;
         bool disabled;
         uint principleAmount;
-        uint lastUpdateTime;
         address[] lenders;
     }
 
@@ -149,7 +148,6 @@ contract SPexBeneficiary {
             receiveAddress: receiveAddress,
             disabled: disabled,
             principleAmount: 0,
-            lastUpdateTime: block.timestamp,
             lenders: new address[](0)
         });
         _miners[minerId] = miner;

--- a/contracts/beneficiary.sol
+++ b/contracts/beneficiary.sol
@@ -270,8 +270,6 @@ contract SPexBeneficiary {
 
     function sellLoan(CommonTypes.FilActorId minerId, uint ceilingAmount, uint pricePerFil) public {
         require(_sales[msg.sender][minerId].amountRemaining == 0, "Sale already exists");
-        uint newAmount = _updateLenderOwedAmount(msg.sender, minerId);
-        require(ceilingAmount <= newAmount, "Insufficient owed amount");
         SellItem memory sellItem = SellItem({
             amountRemaining: ceilingAmount,
             pricePerFil: pricePerFil
@@ -298,8 +296,10 @@ contract SPexBeneficiary {
         require(buyAmount <= sellItem.amountRemaining, "buyAmount larger than amount on sale");
         uint requiredPayment = sellItem.pricePerFil * buyAmount / 1 ether;
         require(msg.value == requiredPayment, "Paid amount not equal to sale price");
-        _updateLenderOwedAmount(seller, minerId);
+        
         _updateLenderOwedAmount(msg.sender, minerId);
+        uint newAmount = _updateLenderOwedAmount(seller, minerId);
+        require(buyAmount <= newAmount, "Insufficient owed amount");
 
         Loan storage sellerLoan = _loans[seller][minerId];
         Loan storage buyerLoan = _loans[msg.sender][minerId];

--- a/contracts/beneficiary.sol
+++ b/contracts/beneficiary.sol
@@ -230,7 +230,9 @@ contract SPexBeneficiary {
         uint64 minerIdUint64 = CommonTypes.FilActorId.unwrap(minerId);
         uint minerBalance = FilAddress.toAddress(minerIdUint64).balance;
         require((minerTotalDebtAmount + msg.value) <= (minerBalance * _maxDebtRate / RATE_BASE), "Debt rate of miner after lend larger than allowed");
-        miner.lenders.push(msg.sender);
+        if (_loans[msg.sender][minerId].lastUpdateTime == 0){
+            miner.lenders.push(msg.sender);
+        }
         _increaseOwedAmounts(msg.sender, minerId, msg.value);
         payable(miner.receiveAddress).transfer(msg.value);
         emit EventLendToMiner(msg.sender, minerId, msg.value);
@@ -389,6 +391,7 @@ contract SPexBeneficiary {
                 if (miner.lenders[i] == lender) {
                     miner.lenders[i] = miner.lenders[miner.lenders.length - 1];
                     miner.lenders.pop();
+                    delete _loans[lender][minerId];
                     break;
                 }
             }


### PR DESCRIPTION
Previously, we calculate fee as relative to the total amount repaid. This method may cause the fee to be higher than the interest earned in cases where the loan duration is short.
So now, we calcluate fee relative to the interest earned.