### PR TITLE
Change loan amount check to be based on principle

### DIFF
--- a/contracts/beneficiary.sol
+++ b/contracts/beneficiary.sol
@@ -228,7 +228,7 @@ contract SPexBeneficiary {
         require(miner.disabled == false, "Lending for this miner is disabled");
         require(msg.value >= _minLendAmount, "Lend amount smaller than minimum allowed");
         _updateOwedAmounts(msg.sender, minerId);
-        require((miner.lastDebtAmount + msg.value) <= miner.maxDebtAmount, "Debt amount after lend large than allowed by miner");
+        require((miner.principleAmount + msg.value) <= miner.maxDebtAmount, "Debt amount after lend large than allowed by miner");
 
         uint64 minerIdUint64 = CommonTypes.FilActorId.unwrap(minerId);
         uint minerBalance = FilAddress.toAddress(minerIdUint64).balance;


### PR DESCRIPTION
This way, the lending quota set by the borrower is the quota of the principle instead of the previous principle-and-interest sum, which more likely matches users' expectations.